### PR TITLE
Fixes #2 and #3 - iis_errorpages errors

### DIFF
--- a/lib/puppet/provider/iis_errorpages/iis_errorpages.rb
+++ b/lib/puppet/provider/iis_errorpages/iis_errorpages.rb
@@ -74,15 +74,15 @@ Puppet::Type.type(:iis_errorpages).provide(:iis_errorpages, :parent => Puppet::P
 	  current_errorpages = self.class.list({resource[:name] => {}})[0][:error_pages]
 	
 	  stringify_statuscode!(error_pages_to_add)
-	  strinfiy_substatuscode!(error_pages_to_add)
+	  stringify_substatuscode!(error_pages_to_add)
 	  stringify_statuscode!(current_errorpages)
-	  strinfiy_substatuscode!(current_errorpages)
+	  stringify_substatuscode!(current_errorpages)
 	  
 	  to_remove = current_errorpages.select do |existing_error_page| 
-		error_page_for_statuscode_exists = found_error_page_with_same_statuscode_as_we_are_adding(error_pages_to_add, existing_error_page)
-		existing_error_page_not_same = !error_pages_to_add.include?(existing_error_page)
+		already_exists = found_error_page_with_same_statuscode_as_we_are_adding(error_pages_to_add, existing_error_page)
+		not_the_same = !error_pages_to_add.include?(existing_error_page)
 
-		error_page_for_statuscode_exists && existing_error_page_not_same
+		already_exists && not_the_same
 	  end 
 
       to_add = error_pages_to_add.reject{|x| if current_errorpages.include?(x); x end}
@@ -127,7 +127,7 @@ Puppet::Type.type(:iis_errorpages).provide(:iis_errorpages, :parent => Puppet::P
   # The subStatusCode can come over as an integer. Convert it to a string 
   # so that when comparing, we know we're comparing apples to apples.
   # [error_pages] The array of hashes where each hash is the custom error page
-  def strinfiy_substatuscode!(error_pages)
+  def stringify_substatuscode!(error_pages)
     return if error_pages.nil?
     error_pages.each do |error_page| 
 	  if !error_page['subStatusCode'].nil?

--- a/lib/puppet/provider/iis_errorpages/iis_errorpages.rb
+++ b/lib/puppet/provider/iis_errorpages/iis_errorpages.rb
@@ -65,16 +65,27 @@ Puppet::Type.type(:iis_errorpages).provide(:iis_errorpages, :parent => Puppet::P
     hash
   end
 
-  def get_complex_property_arg(name, value)
+  def get_complex_property_arg(name, error_pages_to_add)
     args = nil
 
     case name
     when :error_pages
-      to_remove = @initial_properties[:error_pages].reject{|x| if value.include?(x); x end}
-      to_add = value.reject{|x| if @initial_properties[:error_pages].include?(x); x end}
+	  stringify_statuscode!(error_pages_to_add)
+	  strinfiy_substatuscode!(error_pages_to_add)
+	  stringify_statuscode!(@initial_properties[:error_pages])
+	  strinfiy_substatuscode!(@initial_properties[:error_pages])
+	  
+	  to_remove = @initial_properties[:error_pages].select do |existing_error_page| 
+		error_page_for_statuscode_exists = found_error_page_with_same_statuscode_as_we_are_adding(error_pages_to_add, existing_error_page)
+		existing_error_page_not_same = !error_pages_to_add.include?(existing_error_page)
+		
+		error_page_for_statuscode_exists && existing_error_page_not_same
+	  end
+
+      to_add = error_pages_to_add.reject{|x| if @initial_properties[:error_pages].include?(x); x end}
 
       to_remove.map do |page|
-        (args ||= []) << "\"/-[" + page.map{|k,v| "#{k}='#{v}'" if k =~ /statusCode/i}.join(',') + "]\""
+        (args ||= []) << "\"/-[" + page.map{|k,v| "#{k}='#{v}'" if k =~ /statusCode/i}.join('') + "]\""
       end unless to_remove.empty?
 
       to_add.map do |page|
@@ -83,6 +94,12 @@ Puppet::Type.type(:iis_errorpages).provide(:iis_errorpages, :parent => Puppet::P
     end
 
     args
+  end
+  
+  # On subsequent runs, after the custom error pages have been added, 
+  # get_complex_property_arg will return an empty array and this method 
+  # will be called by the parent class. In that case, it should do nothing.
+  def get_simple_property_arg(name, error_pages_to_add)
   end
 
   def execute_flush
@@ -93,5 +110,41 @@ Puppet::Type.type(:iis_errorpages).provide(:iis_errorpages, :parent => Puppet::P
  def execute_delete
    appcmd 'clear', 'config', @resource[:name], "/section:system.webServer/httpErrors"
  end
+ 
+ #-----------Private Methods-----------------
+  private
+  # The statusCode can come over as an integer. Convert it to a string 
+  # so that when comparing, we know we're comparing apples to apples.
+  # [error_pages] The array of hashes where each hash is the custom error page
+  def stringify_statuscode!(error_pages)
+    return if error_pages.nil?
+	error_pages.each { |error_page| error_page['statusCode'] = error_page['statusCode'].to_s }
+  end
+  
+  # The subStatusCode can come over as an integer. Convert it to a string 
+  # so that when comparing, we know we're comparing apples to apples.
+  # [error_pages] The array of hashes where each hash is the custom error page
+  def strinfiy_substatuscode!(error_pages)
+    return if error_pages.nil?
+    error_pages.each do |error_page| 
+	  if !error_page['subStatusCode'].nil?
+	    error_page['subStatusCode'] = error_page['subStatusCode'].to_s 
+	  end
+	end
+  end
+  
+  # Gets a value indicating whether there is an existing custom error page with the same 
+  # statusCode and subStatusCode as the one we're trying to add
+  # [error_pages_to_add] Array of error page hashes to add
+  # [existing_error_page] Existing error page to compare to
+  def found_error_page_with_same_statuscode_as_we_are_adding(error_pages_to_add, existing_error_page)
+    error_pages_to_add.any? do |error_page| 
+	  if (!error_page['subStatusCode'].nil?)
+	    error_page['statusCode'] == existing_error_page['statusCode'] && error_page['subStatusCode'] == existing_error_page['subStatusCode']
+	  else
+	    error_page['statusCode'] == existing_error_page['statusCode'] 
+	  end
+	end
+  end
 
 end


### PR DESCRIPTION
- iis_errorpages::get_complex_property_arg - The to_remove variable was being set in a way that only included the custom error pages that already exist. Instead, it needed to check for error pages that already exist AND that we are now replacing. The new logic checks for existing custom error pages that have the same statusCode and subStatusCode, then checks if what we are adding is any different. 

``` ruby
to_remove = @initial_properties[:error_pages].select do |existing_error_page| 
    error_page_for_statuscode_exists = found_error_page_with_same_statuscode_as_we_are_adding(error_pages_to_add, existing_error_page)
    existing_error_page_not_same = !error_pages_to_add.include?(existing_error_page)

    error_page_for_statuscode_exists && existing_error_page_not_same
 end
```

If so, we add to the array of error pages to remove, since we must remove before we can re-add.
- When setting the statusCode and subStatusCodes, the documentation shows them being set as integers and not strings. However, after being saved, they become strings. So, to compare them later on, both must be strings:

``` ruby
stringify_statuscode!(error_pages_to_add)
 strinfiy_substatuscode!(error_pages_to_add)
 stringify_statuscode!(@initial_properties[:error_pages])
strinfiy_substatuscode!(@initial_properties[:error_pages])
```
- The code that converts the array of key-value pairs into a string for the to_remove was incorrectly joining the key-value pairs with commas. In this case, there is only one key-value pair, _statusCode_, and so the commas created a syntax error. I changed it to join on an empty string instead:

``` ruby
if k =~ /statusCode/i}.join('') + "]\""
```
- The `get_simple_property_arg` method has to be overriden in the iis_errorpages class. Otherwise, on subsequent Puppet runs, when `get_complex_property_arg` returns nil because there is no work to do, the  `get_simple_property_arg` method, with its parent class implemention, runs and causes trouble. I added an override with no implementation:

``` ruby
def get_simple_property_arg(name, error_pages_to_add)
end
```
- Replaced use of `@initial_properties` with a call to `self.class.list` becuase the former is not set when running for the first time. It is only set on subsequent runs.
